### PR TITLE
App crash bugfix

### DIFF
--- a/Clankboard/Clankboard.csproj
+++ b/Clankboard/Clankboard.csproj
@@ -12,7 +12,7 @@
 	<EnableWinUIExperimentalFeatures>true</EnableWinUIExperimentalFeatures>
     <EnableMsixTooling>true</EnableMsixTooling>
     <PlatformTarget>x64</PlatformTarget>
-    <SupportedOSPlatformVersion>10.0.22000.0</SupportedOSPlatformVersion>
+    <SupportedOSPlatformVersion>10.0.20348.0</SupportedOSPlatformVersion>
 	<UseRidGraph>true</UseRidGraph>
 	<PublishAot>False</PublishAot>
 	<RuntimeIdentifier>win-x64</RuntimeIdentifier>

--- a/Clankboard/Classes/AudioManager.cs
+++ b/Clankboard/Classes/AudioManager.cs
@@ -204,9 +204,9 @@ namespace Clankboard
             AudioDevice VACOutputDevice = SettingsManager.GetSetting<AudioDevice>(SettingsManager.SettingTypes.VACOutputDevice);
             AudioDevice InputDevice = SettingsManager.GetSetting<AudioDevice>(SettingsManager.SettingTypes.InputDevice);
 
-            VAC_WaveOut.DeviceNumber = VACOutputDevice.DeviceNumber;
-            Local_WaveOut.DeviceNumber = LocalOutputDevice.DeviceNumber;
-            MicrophoneWaveIn.DeviceNumber = InputDevice.DeviceNumber;
+            VAC_WaveOut.DeviceNumber = Math.Max(0, VACOutputDevice.DeviceNumber);
+            Local_WaveOut.DeviceNumber = Math.Max(0, LocalOutputDevice.DeviceNumber);
+            MicrophoneWaveIn.DeviceNumber = Math.Max(0, InputDevice.DeviceNumber);
 
             VAC_WaveOut.Init(VAC_Mixer);
             Local_WaveOut.Init(Local_Mixer);

--- a/Clankboard/Package.appxmanifest
+++ b/Clankboard/Package.appxmanifest
@@ -12,7 +12,7 @@
   <Identity
     Name="502fb0cc-0cea-479d-9cbf-b98895700fd0"
     Publisher="CN=David Jonjic, O=David Jonjic, L=Eugendorf, S=Salzburg, C=AT"
-    Version="0.1.6.0" />
+    Version="0.1.8.0" />
 
   <mp:PhoneIdentity PhoneProductId="502fb0cc-0cea-479d-9cbf-b98895700fd0" PhonePublisherId="00000000-0000-0000-0000-000000000000"/>
 
@@ -23,8 +23,8 @@
   </Properties>
 
   <Dependencies>
-    <TargetDeviceFamily Name="Windows.Universal" MinVersion="10.0.17763.0" MaxVersionTested="10.0.19041.0" />
-    <TargetDeviceFamily Name="Windows.Desktop" MinVersion="10.0.17763.0" MaxVersionTested="10.0.19041.0" />
+    <TargetDeviceFamily Name="Windows.Universal" MinVersion="10.0.20348.0" MaxVersionTested="10.0.22621.0" />
+    <TargetDeviceFamily Name="Windows.Desktop" MinVersion="10.0.20348.0" MaxVersionTested="10.0.22621.0" />
   </Dependencies>
 
   <Resources>

--- a/Clankboard/Pages/MainWindow.xaml.cs
+++ b/Clankboard/Pages/MainWindow.xaml.cs
@@ -22,6 +22,7 @@ using Windows.UI.WindowManagement;
 using AppWindow = Microsoft.UI.Windowing.AppWindow;
 using AppWindowChangedEventArgs = Microsoft.UI.Windowing.AppWindowChangedEventArgs;
 using Windows.Graphics;
+using Microsoft.UI.Xaml.Hosting;
 
 // To learn more about WinUI, the WinUI project structure,
 // and more about our project templates, see: http://aka.ms/winui-project-info.
@@ -33,7 +34,7 @@ namespace Clankboard;
 public sealed partial class MainWindow : Window
 {
     private AppWindow m_Appwindow;
-    DesktopAcrylicController acrylicController;
+    //DesktopAcrylicController acrylicController;
 
     private SizeInt32 StartingWindowSize = new(Convert.ToInt32(680 * App.DpiScalingFactor), Convert.ToInt32(1000 * App.DpiScalingFactor));
 
@@ -49,8 +50,10 @@ public sealed partial class MainWindow : Window
         m_Appwindow.TitleBar.ButtonBackgroundColor = Colors.Transparent;
         m_Appwindow.TitleBar.ButtonInactiveBackgroundColor = Colors.Transparent;
 
-        acrylicController = new DesktopAcrylicController();
-
+        //if (DesktopAcrylicController.IsSupported())
+        //{
+        //    //acrylicController = new DesktopAcrylicController();
+        //}
         //m_Appwindow.Resize(new Windows.Graphics.SizeInt32((int)(10 * App.DpiScalingFactor), (int)(10 + App.DpiScalingFactor))); // small size to make it go to min size
         // Update the m_Appwindow.Resize call
         m_Appwindow.Resize(StartingWindowSize);


### PR DESCRIPTION
Fixed the 27b error when trying to open the app with no settings.json file on the computer. Fixed by adding Math.Max when setting the NAudio DeviceNumber.